### PR TITLE
Correctly wrap implicit types when the enclosed element itself wasn't implicit or explicit

### DIFF
--- a/lib/rasn1/wrapper.rb
+++ b/lib/rasn1/wrapper.rb
@@ -200,7 +200,7 @@ module RASN1
       el = element.dup
       if el.explicit?
         el.options = el.options.merge(explicit: @implicit)
-      elsif el.implicit?
+      else
         el.options = el.options.merge(implicit: @implicit)
       end
       el

--- a/spec/wrapper_spec.rb
+++ b/spec/wrapper_spec.rb
@@ -152,6 +152,20 @@ module RASN1 # rubocop:disable Metrics/ModuleLength
         wrapper = Wrapper.new(ModelTest.new(id: 1, house: 2), explicit: 7, optional: true)
         expect(wrapper.to_der).to eq(TestWrapper::DER_OPTIONAL_EXPLICITLY_WRAPPED_MODEL)
       end
+
+      it 'implicit behaves the same when using the equivalent non-wrapped' do
+        wrapper = Wrapper.new(Types::Integer.new(value: 4), implicit: 0)
+        unwrapped = Types::Integer.new(value: 4, implicit: 0)
+        wrapper.parse!(unwrapped.to_der)
+        expect(wrapper.to_der).to eq(unwrapped.to_der)
+      end
+
+      it 'explicit behaves the same when using the equivalent non-wrapped' do
+        wrapper = Wrapper.new(Types::Integer.new(value: 4), explicit: 0)
+        unwrapped = Types::Integer.new(value: 4, explicit: 0)
+        wrapper.parse!(unwrapped.to_der)
+        expect(wrapper.to_der).to eq(unwrapped.to_der)
+      end
     end
   end
 end


### PR DESCRIPTION
I noticed a difference between these behaviours:

```
wrapper = Wrapper.new(Types::Integer.new(value: 4), implicit: 0)
unwrapped = Types::Integer.new(value: 4, implicit: 0)
```

The wrapped one doesn't respect the implicit value. I created a test comparing the `to_der` output for the two objects (which should be equivalent). Behaviour prior to the fix:
```
       expected: "\x80\x01\x04"
            got: "\x02\x01\x04"
```

Similarly, trying to parse `unwrapped` using the `wrapper` failed:

```
RASN1::ASN1Error:
       Expected UNIVERSAL PRIMITIVE INTEGER but get CONTEXT PRIMITIVE 0x0 (0x80)
```

The issue was in the `generate_implicit_element`, which would only set the `implicit` tag if the enclosed object was _already_ marked as implicit or explicit.

While the example given is for an integer (which of course has the workaround), this is a problem when you want to wrap a `RASN1::Model` class, for which the only way of setting it as implicit (as far as I know) is using `wrapped`.