### PR TITLE
Add additional failing to_h sequence_of test

### DIFF
--- a/lib/rasn1/model.rb
+++ b/lib/rasn1/model.rb
@@ -393,7 +393,7 @@ module RASN1
       case name_or_idx
       when Symbol
         elt = @elements[name_or_idx]
-      return elt unless elt.is_a?(Proc)
+        return elt unless elt.is_a?(Proc)
 
         @elements[name_or_idx] = elt.call
       when Integer
@@ -628,6 +628,9 @@ module RASN1
       element
     end
 
+    # @author sdaubert
+    # @author lemontree55
+    # @author adfoster-r7
     def private_to_h(element=nil) # rubocop:disable Metrics/CyclomaticComplexity
       my_element = element || root
       my_element = my_element.root if my_element.is_a?(Model)
@@ -636,11 +639,11 @@ module RASN1
                 sequence_of_to_h(my_element)
               when Types::Sequence
                 sequence_to_h(my_element)
-              # @author adfoster-r7
               when Types::Choice
                 raise ChoiceError.new(my_element) if my_element.chosen.nil?
 
-                private_to_h(my_element.value[my_element.chosen])
+                chosen = my_element.value[my_element.chosen]
+                { chosen.name => private_to_h(chosen) }
               when Wrapper
                 wrapper_to_h(my_element)
               else

--- a/lib/rasn1/model.rb
+++ b/lib/rasn1/model.rb
@@ -638,8 +638,9 @@ module RASN1
     # @author adfoster-r7
     def private_to_h(element=nil) # rubocop:disable Metrics/CyclomaticComplexity
       my_element = element || root
-      my_element = my_element.root if my_element.is_a?(Model)
       value = case my_element
+              when Model
+                model_to_h(my_element)
               when Types::SequenceOf
                 sequence_of_to_h(my_element)
               when Types::Sequence
@@ -658,6 +659,15 @@ module RASN1
       end
     end
 
+    def model_to_h(elt)
+      hsh = elt.to_h
+      if root.is_a?(Types::Choice)
+        hsh[hsh.keys.first]
+      else
+        { @elements.key(elt) => hsh[hsh.keys.first] }
+      end
+    end
+
     def sequence_of_to_h(elt)
       if elt.of_type < Model
         elt.value&.map { |el| el.to_h.values.first }
@@ -672,8 +682,7 @@ module RASN1
 
         case el
         when Model
-          hsh = el.to_h
-          [@elements.key(el), hsh[hsh.keys.first]]
+          model_to_h(el).to_a[0]
         when Wrapper
           [unwrap_keyname(@elements.key(el)), wrapper_to_h(el)]
         else

--- a/spec/kerberos_spec.rb
+++ b/spec/kerberos_spec.rb
@@ -843,16 +843,6 @@ module Kerberos
   end
 end
 
-RSpec.shared_examples_for 'a model that produces the same binary data when to_der is called' do
-  let(:input_data) { valid_data }
-
-  describe '#to_der' do
-    it 'produces the same binary data when to_der is called' do
-      expect(described_class.parse(input_data).to_der).to eq(input_data)
-    end
-  end
-end
-
 RSpec.describe Kerberos do
   describe Kerberos::EncryptedData do
     let(:valid_data) do

--- a/spec/ldap_spec.rb
+++ b/spec/ldap_spec.rb
@@ -1,0 +1,242 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "openssl"
+require "time"
+require "base64"
+
+# Implements the model defined by LDAPv3
+# https://www.rfc-editor.org/rfc/rfc4511
+module Ldap
+  class LdapModel < RASN1::Model
+    def self.model_name
+      name.split("::").last.to_sym
+    end
+
+    def self.message_id(name, options = {})
+      custom_primitive_type_for(name, MessageId, options)
+    end
+
+    def self.ldap_string(name, options = {})
+      custom_primitive_type_for(name, LdapString, options)
+    end
+
+    def self.ldap_dn(name, options = {})
+      custom_primitive_type_for(name, LdapDN, options)
+    end
+
+    def self.ldap_relative_dn(name, options = {})
+      custom_primitive_type_for(name, LdapString, options)
+    end
+
+    def self.custom_primitive_type_for(name, clazz, options = {})
+      options[:name] = name
+      proc = proc { |opts| clazz.new(options.merge(opts)) }
+      @root = BaseElem.new(name, proc, nil)
+    end
+
+    private_class_method :custom_primitive_type_for
+  end
+
+  # 4.1.2.  String Types
+  #        LDAPString ::= OCTET STRING -- UTF-8 encoded,
+  #                                     -- [ISO10646] characters
+  class LdapString < RASN1::Types::OctetString
+  end
+
+  # 4.1.3.  Distinguished Name and Relative Distinguished Name
+  #        LDAPDN ::= LDAPString
+  #                    -- Constrained to <distinguishedName> [RFC4514]
+  class LdapDN < LdapString
+  end
+
+  #
+  # 4.1.1.  Message Envelope
+  #
+
+  # 4.1.1.  Message Envelope
+  #        MessageID ::= INTEGER (0 ..  maxInt)
+  #        maxInt INTEGER ::= 2147483647 -- (2^^31 - 1) --
+  class MessageId < RASN1::Types::Integer
+    # XXX: Add constrained types in accordance to the specification
+  end
+
+  # 4.1.10.  Referral
+  #        URI ::= LDAPString     -- limited to characters permitted in
+  #                                -- URIs
+  class LdapUri < LdapString
+  end
+
+  # 4.1.10.  Referral
+  #        Referral ::= SEQUENCE SIZE (1..MAX) OF uri URI
+  class Referral < LdapModel
+    sequence_of :uri, LdapUri
+  end
+
+  # 4.1.9.  Result Message
+  #
+  #        LDAPResult ::= SEQUENCE {
+  #              resultCode         ENUMERATED {
+  #                   success                      (0),
+  #                   ...
+  #                   other                        (80),
+  #                   ...  },
+  #              matchedDN          LDAPDN,
+  #              diagnosticMessage  LDAPString,
+  #              referral           [3] Referral OPTIONAL }
+  class LdapResult < LdapModel
+    def self.components
+      [
+        enumerated(
+          :result_code,
+          enum: {
+            "success" => 0,
+            "operationsError" => 1,
+            "protocolError" => 2,
+            "timeLimitExceeded" => 3,
+            "sizeLimitExceeded" => 4,
+            "compareFalse" => 5,
+            "compareTrue" => 6,
+            "authMethodNotSupported" => 7,
+            "strongerAuthRequired" => 8,
+            #     -- 9 reserved --
+            "referral" => 10,
+            "adminLimitExceeded" => 11,
+            "unavailableCriticalExtension" => 12,
+            "confidentialityRequired" => 13,
+            "saslBindInProgress" => 14,
+            "noSuchAttribute" => 16,
+            "undefinedAttributeType" => 17,
+            "inappropriateMatching" => 18,
+            "constraintViolation" => 19,
+            "attributeOrValueExists" => 20,
+            "invalidAttributeSyntax" => 21,
+            #     -- 22-31 unused --
+            "noSuchObject" => 32,
+            "aliasProblem" => 33,
+            "invalidDNSyntax" => 34,
+            # -- 35 reserved for undefined isLeaf --
+            "aliasDereferencingProblem" => 36,
+            # -- 37-47 unused --
+            "inappropriateAuthentication" => 48,
+            "invalidCredentials" => 49,
+            "insufficientAccessRights" => 50,
+            "busy" => 51,
+            "unavailable" => 52,
+            "unwillingToPerform" => 53,
+            "loopDetect" => 54,
+            # -- 55-63 unused --
+            "namingViolation" => 64,
+            "objectClassViolation" => 65,
+            "notAllowedOnNonLeaf" => 66,
+            "notAllowedOnRDN" => 67,
+            "entryAlreadyExists" => 68,
+            "objectClassModsProhibited" => 69,
+            #-- 70 reserved for CLDAP --
+            "affectsMultipleDSAs" => 71,
+            # -- 72-79 unused --
+            "other" => 80
+          }
+        ),
+        ldap_dn(:matched_dn),
+        ldap_string(:diagnostic_message),
+        wrapper(model(:referral, Referral), implicit: 3, optional: true)
+      ]
+    end
+
+    sequence model_name, content: self.components
+  end
+
+  # 4.7.  Add Operation
+  # AddResponse ::= [APPLICATION 9] LDAPResult
+  class AddResponse < LdapModel
+    sequence model_name,
+            class: :application,
+            implicit: 9,
+            content: [
+              *LdapResult.components
+            ]
+  end
+
+  # 4.1.1.  Message Envelope
+  #              protocolOp      CHOICE {
+  #                   bindRequest           BindRequest,
+  #                   bindResponse          BindResponse,
+  #                   unbindRequest         UnbindRequest,
+  #                   searchRequest         SearchRequest,
+  #                   searchResEntry        SearchResultEntry,
+  #                   searchResDone         SearchResultDone,
+  #                   searchResRef          SearchResultReference,
+  #                   modifyRequest         ModifyRequest,
+  #                   modifyResponse        ModifyResponse,
+  #                   addRequest            AddRequest,
+  #                   addResponse           AddResponse,
+  #                   delRequest            DelRequest,
+  #                   delResponse           DelResponse,
+  #                   modDNRequest          ModifyDNRequest,
+  #                   modDNResponse         ModifyDNResponse,
+  #                   compareRequest        CompareRequest,
+  #                   compareResponse       CompareResponse,
+  #                   abandonRequest        AbandonRequest,
+  #                   extendedReq           ExtendedRequest,
+  #                   extendedResp          ExtendedResponse,
+  #                   ...,
+  #                   intermediateResponse  IntermediateResponse },
+  class ProtocolOp < LdapModel
+    choice model_name,
+           content: [
+             model(:add_response, AddResponse),
+           ]
+  end
+
+  #        LDAPMessage ::= SEQUENCE {
+  #              messageID       MessageID,
+  #              protocolOp      CHOICE {
+  #                   bindRequest           BindRequest,
+  #                   bindResponse          BindResponse,
+  #                   ...,
+  #                   intermediateResponse  IntermediateResponse },
+  #              controls       [0] Controls OPTIONAL }
+  class LdapMessage < LdapModel
+    sequence model_name,
+            content: [
+              message_id(:message_id),
+              model(:protocol_op, ProtocolOp)
+            ]
+  end
+end
+
+# Network traffic extracted from wireshark in conjunction with https://docs.oracle.com/cd/E19693-01/819-0995/6n3cq3apv/index.html#bcadf or https://directory.apache.org/studio/
+RSpec.describe Ldap do
+  describe Ldap::LdapMessage do
+    context "when a AddResponse is parsed" do
+      let(:valid_data) do
+        Base64.decode64 <<~EOF
+          MIQAAACWAgECaYQAAACNCgEKBAAEUDAwMDAyMDJCOiBSZWZFcnI6IERTSUQtMDMxMDA4MkYsIGRhdGEgMCwgMSBhY2Nlc3MgcG9pbnRzCglyZWYgMTogJ2V4YW1wbGUuY29tJwoAo4QAAAAwBC5sZGFwOi8vZXhhbXBsZS5jb20vb3U9UGVvcGxlLGRjPWV4YW1wbGUsZGM9Y29t
+        EOF
+      end
+
+      it_behaves_like "a model that produces the same binary data when to_der is called", :pending
+
+      describe "#parse" do
+        it "parses the data successfully" do
+          expected = {
+            LdapMessage: {
+              message_id: 2,
+              protocol_op: {
+                add_response: {
+                  referral: ["ldap://example.com/ou=People,dc=example,dc=com"],
+                  diagnostic_message: "0000202B: RefErr: DSID-0310082F, data 0, 1 access points\n\tref 1: 'example.com'\n\x00",
+                  matched_dn: "",
+                  result_code: "referral"
+                }
+              }
+            }
+          }
+
+          expect(described_class.parse(valid_data).to_h).to eq(expected)
+        end
+      end
+    end
+  end
+end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -79,6 +79,7 @@ module RASN1 # rubocop:disable Metrics/moduleLength
   ERRORED_VALUE = "\x01\x01\x00".b.freeze
   CHOICE_INTEGER = "\x02\x01\x10".b.freeze
   CHOICE_SEQUENCE = SIMPLE_VALUE
+  NESTED_CHOICE = "\x30\x0b\x04\x03abc\x63\x03\x40\x01\x01".b.freeze
   IMPLICIT_WRAPPED_SUBMODEL = "\x30\x0a\xa5\x08\x02\x01\x0a\x81\x03\x02\x01\x33".b.freeze
   EXPLICIT_WRAPPED_SUBMODEL = "\x30\x0c\x86\x0a\xa4\x08\x02\x01\x0a\x81\x03\x02\x01\x33".b.freeze
   OPTIONAL_VOID_WRAPPED_SUBMODEL = "\x30\x03\x02\x01\x01".b.freeze
@@ -267,10 +268,10 @@ module RASN1 # rubocop:disable Metrics/moduleLength
 
       it 'generates a Hash image of a model with a choice model' do
         model = ModelChoice.parse(CHOICE_INTEGER)
-        expect(model.to_h).to eq({ choice: 16 })
+        expect(model.to_h).to eq({ choice: { id: 16 }})
 
         model = ModelChoice.parse(CHOICE_SEQUENCE)
-        expect(model.to_h).to eq({ choice: { id: 65537, room: 43, house: 4660 } })
+        expect(model.to_h).to eq({ choice: { a_record: { id: 65537, room: 43, house: 4660 } } })
 
         model = ModelChoice.new
         expect { model.to_h }
@@ -289,6 +290,11 @@ module RASN1 # rubocop:disable Metrics/moduleLength
         model[:a_record][:id] = 4
         model[:a_record][:house] = 5
         expect(model.to_h).to eq({ seq: { a_record: { id: 4, house: 5 } } })
+      end
+
+      it 'generates a Hash image of a model with a nested Choice' do
+        model = NestedModelChoice.parse(NESTED_CHOICE)
+        expect(model.to_h).to eq({seq: { os: 'abc', first_choice: { more: { nested_choice:{ id: 1 }}}}})
       end
     end
 

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -161,15 +161,15 @@ module RASN1 # rubocop:disable Metrics/moduleLength
 
       it 'initializes a model from a parameter hash' do
         model = SuperOfModel.new(of: [{ id: 1234 }, { id: 4567, room: 43, house: 21 }])
-        expect(model[:of][:seqof].length).to eq(2)
-        expect(model[:of][:seqof][0]).to be_a(ModelTest)
-        expect(model[:of][:seqof][0][:id].to_i).to eq(1234)
-        expect(model[:of][:seqof][0][:room].value).to be_nil
-        expect(model[:of][:seqof][0][:house].to_i).to eq(0)
-        expect(model[:of][:seqof][1]).to be_a(ModelTest)
-        expect(model[:of][:seqof][1][:id].to_i).to eq(4567)
-        expect(model[:of][:seqof][1][:room].value).to eq(43)
-        expect(model[:of][:seqof][1][:house].to_i).to eq(21)
+        expect(model[:of].length).to eq(2)
+        expect(model[:of][0]).to be_a(ModelTest)
+        expect(model[:of][0][:id].to_i).to eq(1234)
+        expect(model[:of][0][:room].value).to be_nil
+        expect(model[:of][0][:house].to_i).to eq(0)
+        expect(model[:of][1]).to be_a(ModelTest)
+        expect(model[:of][1][:id].to_i).to eq(4567)
+        expect(model[:of][1][:room].value).to eq(43)
+        expect(model[:of][1][:house].to_i).to eq(21)
       end
 
       it 'initializes a model with an implicit wrapper from a parameter hash' do
@@ -412,7 +412,7 @@ module RASN1 # rubocop:disable Metrics/moduleLength
         expect(cert[:signatureValue].value).to eq(der[0x1b6, 128])
 
         issuer = cert[:tbsCertificate][:issuer].to_h
-        expect(issuer[:rdnSequence][0][0][:value]).to eq("\x13\x03org".b)
+        expect(issuer[:issuer][0][0][:value]).to eq("\x13\x03org".b)
       end
 
       it 'may generate a X.509 certificate' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,7 @@ end
 $LOAD_PATH.unshift File.join(File.dirname(__FILE__), '..', 'lib')
 require 'rasn1'
 
-# Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }
 #
 # RSpec.configure do |config|
 #   config.include Binary

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,6 +68,23 @@ module TestModel
                      model(:a_record, ModelTest)]
   end
 
+  class ImplicitModelChoice < RASN1::Model
+    choice :choice,
+           content: [integer(:id, class: :application, implicit: 0),
+                     wrapper(model(:a_record, ModelTest), class: :application, implicit: 1)]
+  end
+
+  class NestedModelChoice < RASN1::Model
+    sequence :seq,
+           content: [octet_string(:os),
+                     choice(:first_choice,
+                            content: [integer(:int, class: :application, implicit: 2),
+                                      sequence(:more, class: :application, implicit: 3,
+                                               content: [model(:nested_choice, ImplicitModelChoice)])
+                                     ])
+                    ]
+  end
+
   class ExplicitTaggedSeq < RASN1::Model
     sequence :seq, explicit: 0, class: :application,
                    content: [integer(:id), integer(:extern_id)]

--- a/spec/support/examples/a_model_that_produces_the_same_binary_when_to_der_is_called.rb
+++ b/spec/support/examples/a_model_that_produces_the_same_binary_when_to_der_is_called.rb
@@ -1,0 +1,9 @@
+RSpec.shared_examples_for 'a model that produces the same binary data when to_der is called' do |*args|
+    let(:input_data) { valid_data }
+
+    describe '#to_der' do
+      it 'produces the same binary data when to_der is called' do
+        expect(described_class.parse(input_data).to_der).to eq(input_data)
+      end
+    end
+  end

--- a/spec/tracer_spec.rb
+++ b/spec/tracer_spec.rb
@@ -183,7 +183,7 @@ module RASN1 # rubocop:disable Metrics/ModuleLength
       end
       expect(io.string).to eq(<<~ENDOFDATA
         seq [ 16 ] SEQUENCE (0x30), len: 13 (0x0d)
-          record [ CONTEXT 5 ] IMPLICIT SEQUENCE (0xa5), len: 11 (0x0b)
+          a_record [ CONTEXT 5 ] IMPLICIT SEQUENCE (0xa5), len: 11 (0x0b)
             id [ 2 ] INTEGER (0x02), len: 1 (0x01)    16 (0x10)
             room [ CONTEXT 0 ] IMPLICIT INTEGER OPTIONAL (0x80), len: 1 (0x01)    7 (0x07)
             house [ CONTEXT 1 ] EXPLICIT INTEGER (0x81), len: 3 (0x03)


### PR DESCRIPTION
I believe this is a separate bug to: https://github.com/lemontree55/rasn1/pull/45 - so I thought I'd create a separate example test failure snippet. Let me know if I should close this off or raise a separate issue 💯 

Current `to_h` output:

```ruby
{
  LdapMessage: {
    message_id: 2,
    protocol_op: {
      # TODO: Wrong
      "": ["ldap://example.com/ou=People,dc=example,dc=com"],
      diagnostic_message:
        "0000202B: RefErr: DSID-0310082F, data 0, 1 access points\n\tref 1: 'example.com'\n\x00",
      matched_dn: "",
      result_code: "referral"
    }
  }
}
```

Expected - Key not blank:

```
expected = {
  LdapMessage: {
    message_id: 2,
    protocol_op: {
      # key present:
      referral: ["ldap://example.com/ou=People,dc=example,dc=com"],
      diagnostic_message:
        "0000202B: RefErr: DSID-0310082F, data 0, 1 access points\n\tref 1: 'example.com'\n\x00",
      matched_dn: "",
      result_code: "referral"
    }
  }
}
```

Wireshark example:

![image](https://github.com/user-attachments/assets/77bfe563-4e3a-41d7-8877-6c9641807abc)
